### PR TITLE
Remote Google Sheet Integration And More

### DIFF
--- a/DiscordCardLinker/CardBot.cs
+++ b/DiscordCardLinker/CardBot.cs
@@ -1,18 +1,23 @@
-﻿using DSharpPlus;
-using DSharpPlus.Entities;
-using DSharpPlus.EventArgs;
-
-using FileHelpers;
-
-using Microsoft.Extensions.Logging;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Net;
 using System.Reflection.Metadata;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+
+using DSharpPlus;
+using DSharpPlus.Entities;
+using DSharpPlus.EventArgs;
+using DSharpPlus.CommandsNext;
+using DSharpPlus.SlashCommands;
+
+using FileHelpers;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace DiscordCardLinker
 {
@@ -33,23 +38,30 @@ namespace DiscordCardLinker
 		private const string curlyRegex = @"{(?!@)(.*?)}";
 		private const string angleRegex = @"<(?!@)(.*?)>";
 		private const string collInfoRegex = @"\((\d+[\w\+]+\d+\w?)\)";
+		private const string abbreviationReductionRegex = @"[^\w\s]+";
+		private const string stripNonWordsRegex = @"\W+";
 
 		private Regex squareCR;
 		private Regex curlyCR;
 		private Regex angleCR;
 		private Regex collInfoCR;
+		private Regex abbreviationReductionCR;
+		private Regex stripNonWordsCR;
 
 		//Maybe split this into groups: has subtitles, has nicks, etc
 		private List<CardDefinition> Cards { get; set; }
+
+		private bool Loading { get; set; }
 
 		private Dictionary<string, List<CardDefinition>> CardTitles { get; set; }
 		private Dictionary<string, List<CardDefinition>> CardSubtitles { get; set; }
 		private Dictionary<string, List<CardDefinition>> CardFullTitles { get; set; }
 		private Dictionary<string, List<CardDefinition>> CardNicknames { get; set; }
+		private Dictionary<string, List<CardDefinition>> CardPersonas { get; set; }
 		private Dictionary<string, CardDefinition> CardCollInfo{ get; set; }
 
 		
-		private Queue<(string searchString, CardDefinition card)> Cache { get; set; }
+		//private Queue<(string searchString, CardDefinition card)> Cache { get; set; }
 
 		public CardBot(Settings settings)
 		{
@@ -58,13 +70,44 @@ namespace DiscordCardLinker
 			curlyCR = new Regex(curlyRegex, RegexOptions.Compiled);
 			angleCR = new Regex(angleRegex, RegexOptions.Compiled);
 			collInfoCR = new Regex(collInfoRegex, RegexOptions.Compiled);
+			abbreviationReductionCR = new Regex(abbreviationReductionRegex, RegexOptions.Compiled);
+			stripNonWordsCR = new Regex(stripNonWordsRegex, RegexOptions.Compiled);
 
-			LoadCardDefinitions();
-			Cache = new Queue<(string searchString, CardDefinition card)>();
+			LoadCardDefinitions().Wait();
 		}
 
-		public void LoadCardDefinitions()
+		private async Task DownloadGoogleSheet()
 		{
+			//https://docs.google.com/spreadsheets/d/1-0C3sAm78A0x7-w_rfuWuH87Fta60m2xNzmAE2KFBNE/export?format=tsv
+
+			HttpWebRequest request = (HttpWebRequest)WebRequest.Create($"https://docs.google.com/spreadsheets/d/{CurrentSettings.GoogleSheetID}/export?format=tsv");
+			request.Method = "GET";
+
+			try
+			{
+				var webResponse = await request.GetResponseAsync();
+				using (Stream webStream = webResponse.GetResponseStream() ?? Stream.Null)
+				using (StreamReader responseReader = new StreamReader(webStream))
+				{
+					string response = responseReader.ReadToEnd();
+					File.WriteAllText(CurrentSettings.CardFilePath, response);
+				}
+			}
+			catch (Exception e)
+			{
+				Console.Out.WriteLine(e);
+			}
+		}
+
+		public async Task LoadCardDefinitions()
+		{
+			Loading = true;
+
+			if(!String.IsNullOrWhiteSpace(CurrentSettings.GoogleSheetID))
+			{
+				await DownloadGoogleSheet();
+			}
+
 			var engine = new FileHelperEngine<CardDefinition>(Encoding.UTF8);
 			Cards = engine.ReadFile(CurrentSettings.CardFilePath).ToList();
 
@@ -72,47 +115,73 @@ namespace DiscordCardLinker
 			CardSubtitles = new Dictionary<string, List<CardDefinition>>();
 			CardFullTitles = new Dictionary<string, List<CardDefinition>>();
 			CardNicknames = new Dictionary<string, List<CardDefinition>>();
+			CardPersonas = new Dictionary<string, List<CardDefinition>>();
 			CardCollInfo = new Dictionary<string, CardDefinition>();
-
-			string fulltitle = "";
 
 			foreach(var card in Cards)
 			{
-				AddEntry(CardTitles, card.Title.ToLower().Trim(), card);
-				AddEntry(CardSubtitles, card.Subtitle.ToLower().Trim(), card);
-				if(!String.IsNullOrWhiteSpace(card.Subtitle))
-				{
-					fulltitle = $"{card.Title.Trim()}, {card.Subtitle.Trim()}{card.TitleSuffix.Trim()}";
-				}
-				else
-				{
-					fulltitle = $"{card.Title.Trim()}{card.TitleSuffix.Trim()}";
-				}
-				AddEntry(CardFullTitles, $"{fulltitle.ToLower().Trim()}", card);
+				AddEntry(CardTitles, ScrubInput(card.Title), card);
+				AddEntry(CardSubtitles, ScrubInput(card.Subtitle), card);
 
+				string fulltitle = $"{card.Title}{card.Subtitle}{card.TitleSuffix}";
+				AddEntry(CardFullTitles, ScrubInput(fulltitle), card);
 
 				if(!String.IsNullOrWhiteSpace(card.Subtitle))
 				{
-					AddEntry(CardNicknames, GetLongAbbreviation(card.Subtitle.ToLower().Trim()), card);
+					fulltitle = $"{card.Subtitle}{card.TitleSuffix}";
+					AddEntry(CardFullTitles, ScrubInput(fulltitle), card);
+				}
+
+				foreach (string entry in card.Personas.Split(","))
+				{
+					if (String.IsNullOrWhiteSpace(entry))
+						continue;
+
+					AddEntry(CardPersonas, ScrubInput(entry), card);
+				}
+
+				if (!String.IsNullOrWhiteSpace(card.Subtitle))
+				{
+					AddEntry(CardNicknames, GetLongAbbreviation(card.Subtitle), card);
 				}
 				else
 				{
-					AddEntry(CardNicknames, GetLongAbbreviation(card.Title.ToLower().Trim()), card);
+					AddEntry(CardNicknames, GetLongAbbreviation(card.Title), card);
 				}
 
 				foreach (string entry in card.Nicknames.Split(","))
 				{
-					AddEntry(CardNicknames, entry.ToLower().Trim(), card);
+					if (String.IsNullOrWhiteSpace(entry))
+						continue;
+
+					AddEntry(CardNicknames, ScrubInput(entry), card);
 				}
 
-				CardCollInfo.Add(card.CollInfo.ToLower().Trim(), card);
+				CardCollInfo.Add(ScrubInput(card.CollInfo), card);
 			}
+
+			Loading = false;
+		}
+
+		private string ScrubInput(string input, bool stripSymbols=true)
+		{
+			string output = input.ToLower();
+			output = output.Trim();
+			if(stripSymbols)
+			{
+				output = stripNonWordsCR.Replace(output, "");
+			}
+			
+			return output;
 		}
 
 		private string GetLongAbbreviation(string input)
 		{
+			input = input.ToLower().Trim();
+			input = input.Replace("-", " ");
+			input = abbreviationReductionCR.Replace(input, "");
 			string abbr = new string(
-				input.Split(new char[] { ' ', '-' }, StringSplitOptions.RemoveEmptyEntries)
+				input.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
 							.Where(s => s.Length > 0 && char.IsLetter(s[0]))
 							.Select(s => s[0])
 							.ToArray());
@@ -146,15 +215,33 @@ namespace DiscordCardLinker
 			Client.MessageCreated += OnMessageCreated;
 			Client.MessageReactionAdded += OnReactionAdded;
 
+			var slash = Client.UseSlashCommands(new SlashCommandsConfiguration()
+			{
+				Services = new ServiceCollection().AddSingleton<CardBot>(this).BuildServiceProvider()
+			});
+
+			//TODO: remove this id
+			slash.RegisterCommands<LoremasterSlashCommands>(699957633121255515);
+
 			await Client.ConnectAsync();
 		}
 
 		private async Task OnReactionAdded(DiscordClient sender, MessageReactionAddEventArgs e)
 		{
+			if (Loading)
+			{
+				await Task.Delay(3000);
+				if (Loading)
+					return;
+			}
+				
+			if (e.User == Client.CurrentUser)
+				return;
+
 			if (e.Message.Author != Client.CurrentUser)
 				return;
 
-			if (e.Message.ReferencedMessage.Author != e.User)
+			if (e.Message.ReferencedMessage.Author != e.User && !e.Message.ReferencedMessage.Author.IsBot)
 				return;
 
 			MatchType type;
@@ -191,18 +278,23 @@ namespace DiscordCardLinker
 						await e.Message.ModifyAsync(card.WikiURL);
 						break;
 				}
-
-				AddSuccessfulSearch(search, card);
-
 			}
-
-			
 		}
 
 		private async Task OnMessageCreated(DiscordClient sender, MessageCreateEventArgs e)
 		{
+			if (Loading)
+			{
+				await Task.Delay(3000);
+				if (Loading)
+					return;
+			}
+
+			//Absolutely can't let infinite response loops through
 			if (e.Message.Author.IsBot)
 				return;
+
+			await Task.Delay(500);
 
 			string content = e.Message.Content;
 
@@ -211,14 +303,11 @@ namespace DiscordCardLinker
 			foreach (Match match in curlyCR.Matches(content))
 			{
 				requests.Add((MatchType.Wiki, match.Groups[1].Value));
-
-				//await e.Message.RespondAsync($"Here's a wiki link for ''!");
 			}
 
 			foreach (Match match in squareCR.Matches(content))
 			{
 				requests.Add((MatchType.Image, match.Groups[1].Value));
-				//await e.Message.RespondAsync($"https://lotrtcgwiki.com/images/LOTR.jpg");
 			}
 
 			//foreach (Match match in angleCR.Matches(content))
@@ -260,31 +349,13 @@ namespace DiscordCardLinker
 					await SendCollisions(e, type, searchString, candidates);
 				}
 			}
-				
-
-		}
-
-		private void AddSuccessfulSearch(string search, CardDefinition card)
-		{
-			search = search.ToLower().Trim();
-			Cache.Enqueue((search, card));
-			if(Cache.Count > 100)
-			{
-				Cache.Dequeue();
-			}
 		}
 
 		private async Task<List<CardDefinition>> PerformSearch(string searchString)
 		{
 			var candidates = new List<CardDefinition>();
 
-			string lowerSearch = searchString.ToLower().Trim();
-			if(Cache.Any(x => x.searchString == searchString))
-			{
-				var card = Cache.Where(x => x.searchString == lowerSearch).First().card;
-				candidates.Add(card);
-				return candidates;
-			}
+			string lowerSearch = ScrubInput(searchString);
 
 			if (CardSubtitles.ContainsKey(lowerSearch))
 			{
@@ -316,6 +387,12 @@ namespace DiscordCardLinker
 				return candidates;
 			}
 
+			if (CardPersonas.ContainsKey(lowerSearch))
+			{
+				candidates.AddRange(CardPersonas[lowerSearch]);
+				return candidates;
+			}
+
 			//TODO: fuzzy search on all of the above
 			return candidates;
 		}
@@ -331,8 +408,6 @@ namespace DiscordCardLinker
 					await SendWikiLink(e, card);
 					break;
 			}
-
-			AddSuccessfulSearch(search, card);
 		}
 
 		private async Task SendImage(MessageCreateEventArgs e, CardDefinition card)
@@ -343,9 +418,6 @@ namespace DiscordCardLinker
 		private async Task SendWikiLink(MessageCreateEventArgs e, CardDefinition card)
 		{
 			await e.Message.RespondAsync(card.WikiURL);
-			//var msg = await new DiscordMessageBuilder()
-			//	.With
-			//e.Message.RespondAsync()
 		}
 
 		private async Task SendNotFound(MessageCreateEventArgs e, string search)
@@ -365,10 +437,24 @@ namespace DiscordCardLinker
 			switch (type)
 			{
 				case MatchType.Image:
-					response += $"Found multiple potential candidates for card image `{search}`.\nReact with the option you'd like to display:\n\n";
+					if (e.Author.IsBot)
+					{
+						response += $"Found multiple potential candidates for card image `{search}`.\nTry again with one of the following:\n\n";
+					}
+					else
+					{
+						response += $"Found multiple potential candidates for card image `{search}`.\nReact with the option you'd like to display:\n\n";
+					}
 					break;
 				case MatchType.Wiki:
-					response += $"Found multiple potential candidates for card wiki page `{search}`.\nReact with the option you'd like to display:\n\n";
+					if (e.Author.IsBot)
+					{
+						response += $"Found multiple potential candidates for card wiki page `{search}`.\nTry again with one of the following:\n\n";
+					}
+					else
+					{
+						response += $"Found multiple potential candidates for card wiki page `{search}`.\nReact with the option you'd like to display:\n\n";
+					}
 					break;
 			}
 			
@@ -401,6 +487,7 @@ namespace DiscordCardLinker
 
 			foreach (var option in menu)
 			{
+
 				if (option == "-")
 					continue;
 

--- a/DiscordCardLinker/CardDefinition.cs
+++ b/DiscordCardLinker/CardDefinition.cs
@@ -21,5 +21,6 @@ namespace DiscordCardLinker
 		public string TitleSuffix;
 
 		public string Nicknames;
+		public string Personas;
 	}
 }

--- a/DiscordCardLinker/DiscordCardLinker.csproj
+++ b/DiscordCardLinker/DiscordCardLinker.csproj
@@ -6,11 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DSharpPlus" Version="4.0.1" />
-    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.0.1" />
-    <PackageReference Include="DSharpPlus.Interactivity" Version="4.0.1" />
-    <PackageReference Include="FileHelpers" Version="3.4.2" />
+    <PackageReference Include="DSharpPlus" Version="4.2.0-nightly-00972" />
+    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.2.0-nightly-00972" />
+    <PackageReference Include="DSharpPlus.Interactivity" Version="4.2.0-nightly-00972" />
+    <PackageReference Include="FileHelpers" Version="3.5.0" />
     <PackageReference Include="FuzzySharp" Version="2.0.2" />
+    <PackageReference Include="IDoEverything.DSharpPlus.SlashCommands" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/DiscordCardLinker/LoremasterSlashCommands.cs
+++ b/DiscordCardLinker/LoremasterSlashCommands.cs
@@ -1,0 +1,32 @@
+﻿using System.Diagnostics;
+using System.Threading.Tasks;
+
+
+using DSharpPlus;
+using DSharpPlus.Entities;
+
+using DSharpPlus.SlashCommands;
+
+namespace DiscordCardLinker
+{
+	public class LoremasterSlashCommands : ApplicationCommandModule
+	{
+		[SlashCommand("reload", "Retrieves card definitions from the public Google sheet and reconstructs the card definitions.")]
+		public async Task ReloadCardDefinitions(InteractionContext ctx)
+		{
+			await ctx.CreateResponseAsync(InteractionResponseType.DeferredChannelMessageWithSource,
+				new DiscordInteractionResponseBuilder().WithContent("Rebuilding card definition database..."));
+
+			var sw = new Stopwatch();
+			sw.Start();
+
+			var bot = (CardBot)ctx.Services.GetService(typeof(CardBot));
+			await bot.LoadCardDefinitions();
+
+			sw.Stop();
+
+			await ctx.FollowUpAsync(new DiscordFollowupMessageBuilder().WithContent($"Completed card definition rebuild in {sw.Elapsed.TotalSeconds} seconds.  It's ready to go!"));
+		}
+
+	}
+}

--- a/DiscordCardLinker/Settings.cs
+++ b/DiscordCardLinker/Settings.cs
@@ -12,12 +12,8 @@ namespace DiscordCardLinker
 		public const string DefaultPath = "./settings.json";
 
 		public string Token { get; set; }            = Environment.GetEnvironmentVariable("TOKEN");
-		public long ClientID { get; set; }           = long.Parse(Environment.GetEnvironmentVariable("CLIENTID"));
-		public long Permissions { get; set; }        = long.Parse(Environment.GetEnvironmentVariable("PERMISSIONS"));
-		public string BaseImageURL { get; set; }     = Environment.GetEnvironmentVariable("BASEIMAGEURL");
-		public string BaseWikiURL { get; set; }      = Environment.GetEnvironmentVariable("BASEWIKIURL");
 		public string CardFilePath { get; set; }     = "cards.tsv";
-		public int MaxImagesPerMessage { get; set; } = int.Parse(Environment.GetEnvironmentVariable("MAXIMAGESPERMESSAGE"));
+		public string GoogleSheetID { get; set; }    //= Environment.GetEnvironmentVariable("GOOGLESHEETID");
 
 		public void StoreSettings(string path= DefaultPath)
 		{


### PR DESCRIPTION
Some major overhauls, especially to the way that card names are stored, which now are reduced entirely to alphanumeric characters, to eliminate all issues with punctuation and spacing.

The system now attempts to connect to a Google sheet and load that information locally before constructing the card definitions.  This permits the community to step in and make changes as issues are discovered, distributing the workload.  To support this, a /reload slashcommand has been added so that users can force the bot to redownload any time that changes have been made.

(I've created a google sheet here if you want to duplicate it in a space that your PC controls: https://docs.google.com/spreadsheets/d/1yHDBxPuTTpZy5IVVRKw1BEGK2rOI79wMlaX3purSP0A/edit#gid=0).  Once that's done, the document ID will need to be copied into a new environment variable (see the commented out section in Settings.cs).

Supporting this last feature required moving the dependencies for DSharpPlus over to a nightly build which isn't on the standard nuget.  Instructions for switching to that are here: https://dsharpplus.github.io/articles/misc/nightly_builds.html

If you'd rather just copy-paste the DLLs, let me know and I'll pass you the binaries.

Supporting slashcommands also requires new permissions for the bot in Discord.  This can be done in-place without kicking the bot, the URL will just need to be sent to a server admin and have it reauthorized with the following seven checkmarks: 
![image](https://user-images.githubusercontent.com/1814132/130923725-6de5457f-10c5-4658-b9f8-9ada3cf7ee9e.png)

Also added is support for a separate Personas column, which is going to be more useful in general than the Subtitle column is.  It basically acts as a second Nicknames group, which is evaluated before them.

4 of the 5 open issues are resolved with this PR, and I suspect the 5th will as well.

The code was also cleaned up some, including removing a bunch of vestigial settings that weren't actually used.