### PR TITLE
Importing all the updates from the LOTR version of the bot (except spreadsheets)

### DIFF
--- a/DiscordCardLinker/CardDefinition.cs
+++ b/DiscordCardLinker/CardDefinition.cs
@@ -8,14 +8,22 @@ namespace DiscordCardLinker {
 	[DelimitedRecord("\t")]
 	[IgnoreFirst]
 	public class CardDefinition {
+		[FieldTrim(TrimMode.Both)]
 		public string ID;
+		[FieldTrim(TrimMode.Both)]
 		public string ImageURL;
+		[FieldTrim(TrimMode.Both)]
 		public string WikiURL;
+		[FieldTrim(TrimMode.Both)]
 		public string CollInfo;
 
+		[FieldTrim(TrimMode.Both)]
 		public string DisplayName;
+		[FieldTrim(TrimMode.Both)]
 		public string Title;
+		[FieldTrim(TrimMode.Both)]
 		public string Subtitle;
+		[FieldTrim(TrimMode.Both)]
 		public string TitleSuffix;
 
 		public string Nicknames;

--- a/DiscordCardLinker/HashSetExtensions.cs
+++ b/DiscordCardLinker/HashSetExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DiscordCardLinker
+{
+	public static class HashSetExtensions
+	{
+		public static bool AddRange<T>(this HashSet<T> set, IEnumerable<T> items)
+		{
+			bool allIn = true;
+			foreach (var item in items)
+			{
+				allIn &= set.Add(item);
+			}
+
+			return allIn;
+		}
+	}
+}


### PR DESCRIPTION
This includes all of the improvements done over the last year or so to the LOTR version of this bot, *except* for the spreadsheet rework, which was objected to last time.  These changes include:

1. Expanded the input and key scrubbing so that all non-alphanumeric characters are ignored.  This makes anything short of a literal misspelling work (spacing and punctuation errors now have no effect)
2. Removed caching support (it "locked-in" user selections into the cache, which isn't great for situations where there are multiple legit alternatives, which conflicts with the search support below)
3. Combined all query options together instead of short-circuiting out if a higher priority tier is found (to ensure that all alternatives are found)
4. Added fuzzy-ish search at the end of the query process to search for cards containing the query rather than exactly matching it (if the query is longer than 2 characters).
5. Overhauled bot to utilize buttons and dropdowns instead of reactions.  Dropdown can only be used by the person who summoned the bot or the server owner (which is the same behavior as the reactions).  Anyone can open the dropdown to browse the results, however.
6. Bot responses automatically include a "delete" button which can be used to eliminate unwanted responses (tho only by the person who summoned it or the server owner)
7. Bot responses automatically include a "wiki" button which links unobtrusively to the wiki link
8. Added support for the bot responding in Discord threads
9. Added check to ignore any spreadsheet entries that have a blank ID or coll info (as a proxy for skipping blank lines in the spreadsheet)
10. Added column trimming, since a bunch of the entries have random spaces in them
11. Temporarily disabled loading from the nicknames field as the current iteration of the spreadsheet results in tens of thousands of redundant search parameters which slows down the bot, almost none of which are actually increasing usability.  The useful nicks are now covered by the input scrubbing typo compensation + dynamic drop-down switching.
12. Added handling for a 25-card limit in the response (the max that a dropdown can hold, and coincidentally the maximum number of reacts that could have been used on the old bot anyway)
13. Altered the summoning syntax to [[card name]], to cut down dramatically on false positive responses (and to match familiar syntax for other popular bots)
14. Removed {{card name}} syntax, as the image response now always includes a button that will link to the wiki

----

Gallery of major change results (ignore the bot name, I lazily used the LOTR bot for testing):

Abbreviations of cards with and without punctuation:
![image](https://user-images.githubusercontent.com/1814132/189810932-7682b899-e4c6-474c-8d29-e5df2bf945d2.png)

The drop-down when multiple cards are found:
![image](https://user-images.githubusercontent.com/1814132/189811018-857dac6d-f1b8-42f1-99ad-4e69d7614e6c.png)

After selecting an image, the dropdown doesn't go away (until the "accept" button is clicked), allowing one to re-select an option when searching for a particular variant:
![image](https://user-images.githubusercontent.com/1814132/189811086-f3a4e5e5-4f2b-4e6c-8126-a59e4c3f5270.png)

A slightly different message when more than 25 cards are found:
![image](https://user-images.githubusercontent.com/1814132/189811229-e65a5dfe-9166-4db6-b2ed-75e90c2559a9.png)

Delete button on failed searches.  Also shows the split for cards that have (sub-names in parentheses) in the title; both are now searchable: 
![image](https://user-images.githubusercontent.com/1814132/189811405-2b1ca53d-cc3c-4016-8e69-daea03655e58.png)

No amount of space or punctuation errors get in the way, and as you can see all of the search results are relevant (none of the options not shown had anything except "obi-wan" in the title):
![image](https://user-images.githubusercontent.com/1814132/189811681-c2cf99c5-bc4d-4e80-b88b-63f42ad38fd9.png)

Demonstrating the use of search when only part of a title is matched:
![image](https://user-images.githubusercontent.com/1814132/189811802-56f0b494-954f-4157-9a42-44451eb577dd.png)
